### PR TITLE
Limit email intent to mail clients

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle" />
@@ -14,8 +14,6 @@
             <option value="$PROJECT_DIR$/library" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,7 +12,7 @@
       </MavenGeneralSettings>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
-    ext.java_version = JavaVersion.VERSION_1_8
-    ext.kotlin_version = "1.4.30"
+    ext.java_version = JavaVersion.VERSION_11
+    ext.kotlin_version = "1.5.31"
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.2"
+        classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.java_version = JavaVersion.VERSION_1_8
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.6.21"
     
     repositories {
         google()
@@ -9,13 +9,6 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.java_version = JavaVersion.VERSION_11
+    ext.java_version = JavaVersion.VERSION_1_8
     ext.kotlin_version = "1.5.31"
     
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,25 +5,25 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 31
     }
 
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_1_8
-        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_11
     }
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation "androidx.startup:startup-runtime:1.0.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.31"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
+    implementation 'androidx.core:core-ktx:1.6.0'
+    implementation "androidx.startup:startup-runtime:1.1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,15 +1,15 @@
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'kotlin-kapt'
+    id "com.android.library"
+    id "kotlin-android"
+    id "kotlin-kapt"
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 32
     }
 
     compileOptions {
@@ -22,8 +22,10 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation "androidx.startup:startup-runtime:1.1.0"
+    implementation "androidx.databinding:viewbinding:7.2.0"
+    implementation "androidx.lifecycle:lifecycle-common-java8:2.4.1"
+    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.startup:startup-runtime:1.1.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,11 +13,11 @@ android {
     }
 
     compileOptions {
-        targetCompatibility JavaVersion.VERSION_11
-        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/library/src/main/java/dev/udell/open/util/LogReader.kt
+++ b/library/src/main/java/dev/udell/open/util/LogReader.kt
@@ -130,6 +130,7 @@ class LogReader(context: Context) {
 
         if (emailRecipient != null) {
             emailIntent.putExtra(Intent.EXTRA_EMAIL, arrayOf(emailRecipient.toString()))
+                .setData(Uri.parse("mailto:"))
         }
 
         val logUri = FileProvider.getUriForFile(

--- a/library/src/main/java/dev/udell/open/util/LogReader.kt
+++ b/library/src/main/java/dev/udell/open/util/LogReader.kt
@@ -128,11 +128,6 @@ class LogReader(context: Context) {
             emailIntent.type = "application/zip"
         }
 
-        if (emailRecipient != null) {
-            emailIntent.putExtra(Intent.EXTRA_EMAIL, arrayOf(emailRecipient.toString()))
-                .setData(Uri.parse("mailto:"))
-        }
-
         val logUri = FileProvider.getUriForFile(
             appContext,
             appContext.packageName + ".logprovider",
@@ -213,8 +208,16 @@ class LogReader(context: Context) {
                 progress.show()
             } else {
                 // Not running on CrOS AFAICT; use a normal Android intent
-                action = Intent(Intent.ACTION_SEND)
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT + Intent.FLAG_ACTIVITY_NEW_TASK)
+
+                action = if (recipient == null) {
+                    Intent(Intent.ACTION_SEND)
+                } else {
+                    Intent(Intent.ACTION_SENDTO)
+                        .setData(Uri.parse("mailto:"))
+                        .putExtra(Intent.EXTRA_EMAIL, arrayOf(recipient.toString()))
+                }
+
+                action.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT + Intent.FLAG_ACTIVITY_NEW_TASK)
                     .setType("text/plain")
                     .putExtra(Intent.EXTRA_SUBJECT, subject)
                     .putExtra(Intent.EXTRA_TEXT, body)

--- a/library/src/main/java/dev/udell/open/util/LogReader.kt
+++ b/library/src/main/java/dev/udell/open/util/LogReader.kt
@@ -160,6 +160,9 @@ class LogReader(context: Context) {
         /**
          * Helper function to create an email-the-developer `Intent`. Used to send the log, but
          * can also be used standalone, such as for a "Contact" link.
+         *
+         * If the `recipient` parameter is specified, the resulting `Intent` will be limited to
+         * email clients. Be aware that such an `Intent` does not support attachments!
          */
         @TargetApi(Build.VERSION_CODES.LOLLIPOP)
         fun makeEmailIntent(
@@ -205,6 +208,7 @@ class LogReader(context: Context) {
                     Intent(Intent.ACTION_SEND)
                         .putExtra(Intent.EXTRA_SUBJECT, subject)
                         .putExtra(Intent.EXTRA_TEXT, body)
+                        .setType("text/plain")
                 } else {
                     Intent(Intent.ACTION_SENDTO)
                         .setData(Uri.parse(mailTo))


### PR DESCRIPTION
The `LogReader` bug addressed here is that, if a user selected a non-email handler for the `SEND` intent with the "Always" option, they'll never be able to email the log thereafter - it'll always go to that _other_ handler. Since email is the primary vehicle for user submission of logs, this isn't acceptable.

The fix is to use a `sendto:` URI rather than a generic `SEND` intent if a recipient is supplied to `shareLog()`. If no recipient is supplied, the user should get full set of share options.

Note: I've also updated the project's dependencies, it had been a while.